### PR TITLE
feat: upload rich diagnostic fields to AICOEVO

### DIFF
--- a/src/privacy/uploader.ts
+++ b/src/privacy/uploader.ts
@@ -80,6 +80,10 @@ export interface UploadPayload {
     category: string;
     status: string;
     message: string;
+    detail?: string;
+    version?: string | null;
+    severity?: string | null;
+    fixCommand?: string | null;
   }>;
   systemInfo: SystemInfo;
 }
@@ -95,6 +99,10 @@ export function createPayload(results: ScanResult[], score: ScoreResult): Upload
       category: r.category,
       status: r.status,
       message: sanitize(r.message),
+      detail: r.detail ? sanitize(r.detail) : undefined,
+      version: r.version || null,
+      severity: r.severity || null,
+      fixCommand: r.fixCommand ? sanitize(r.fixCommand) : null,
     })),
     systemInfo: collectSystemInfo(),
   };


### PR DESCRIPTION
## Summary
- Upload `detail`, `version`, `severity`, `fixCommand` alongside scan results
- Enables the platform (aicoevo-platform PR #51) to generate complete bounty descriptions with environment context
- Part of the bounty completeness gate feature (score < 4 → draft, >= 4 → open)

## Test plan
- [ ] Run a local scan and verify the uploaded payload includes the new fields
- [ ] Verify the stash API accepts the new optional fields without errors
- [ ] Check that claim page auto-creates bounties with structured descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)