### PR TITLE
feat: pipeline sync feedback + auto stash upload (P1+P2)

### DIFF
--- a/bin/agent-lite.js
+++ b/bin/agent-lite.js
@@ -579,6 +579,29 @@ async function syncEvents(deps = {}) {
       writeAdvice(remote.data.advice, deps);
     }
 
+    // 展示同步反馈：匹配结果和悬赏草稿
+    if (remote.data) {
+      const accepted = remote.data.accepted || 0;
+      const advice = remote.data.advice;
+      const drafts = remote.data.bountyDrafts;
+      if (accepted > 0) {
+        const parts = [`[AICOEVO] 已上传 ${accepted} 条事件`];
+        if (advice) {
+          const conf = typeof advice.confidence === 'number' ? advice.confidence : 0;
+          if (conf >= 0.6) {
+            parts.push(`匹配到已有方案 (置信度 ${Math.round(conf * 100)}%)`);
+          } else if (advice.summary) {
+            parts.push(String(advice.summary).split('\n')[0]);
+          }
+        }
+        if (drafts && drafts.length > 0) {
+          const d = drafts[0];
+          parts.push(`已创建悬赏草稿: ${d.title || d.id}`);
+        }
+        (deps.stderr || process.stderr).write(parts.join(' | ') + '\n');
+      }
+    }
+
     return { ok: true, uploaded: pending.length, data: remote.data };
   });
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,13 +4,13 @@ import { runAllScanners, getScannerById } from './scanners/registry';
 import { generateJsonReport } from './report/json';
 import { generateHtmlReport } from './report/html';
 import { getConsent, saveConsent } from './privacy/consent';
-import { createPayload, saveLocal } from './privacy/uploader';
+import { createPayload, saveLocal, stashData } from './privacy/uploader';
 import { loadPreviousReport, loadHistory } from './privacy/uploader';
 import { writeFileSync, mkdirSync, existsSync } from 'fs';
 import { join } from 'path';
 import { execSync } from 'child_process';
 import { requestRemoteJson } from './web/remote-json';
-import { getCommunityApiBase } from './web/community-config';
+import { getCommunityApiBase, buildCommunityClaimUrl } from './web/community-config';
 import { enableAgentExperience, getAgentLocalStatus, pauseAgentUploads, syncAgentEvents } from './agent/local-state';
 import type { ScoreResult } from './scanners/types';
 import { VERSION } from './constants';
@@ -95,6 +95,19 @@ async function cliMode(wantJson: boolean, wantHtml: boolean) {
   }
 
   saveLocal(createPayload(results, score));
+
+  // 自动上传 stash 到 AICOEVO（失败不影响本地）
+  const consent = getConsent();
+  if (consent) {
+    try {
+      const payload = createPayload(results, score);
+      const apiBase = getCommunityApiBase();
+      const resp = await stashData(payload, apiBase);
+      console.log(`\n[AICOEVO] 扫描数据已上传，查看方案: ${buildCommunityClaimUrl(resp.token)}`);
+    } catch (err) {
+      // 上传失败不影响本地保存
+    }
+  }
 }
 
 // ==================== Web UI 模式 ====================

--- a/src/privacy/uploader.ts
+++ b/src/privacy/uploader.ts
@@ -128,6 +128,46 @@ export function saveLocal(payload: UploadPayload): string {
   return '';
 }
 
+/** Stash API 响应 */
+export interface StashResponse {
+  token: string;
+  claim_url: string;
+  ttl_seconds: number;
+}
+
+/** 上传扫描数据到 AICOEVO stash API（与 MacAICheck stashData 对齐） */
+export async function stashData(payload: UploadPayload, apiBase: string): Promise<StashResponse> {
+  const fingerprint = JSON.stringify({
+    platform: 'Windows',
+    userAgent: `WinAICheck/${process.version}`,
+    system: payload.systemInfo,
+    score: payload.score,
+    failCount: payload.results.filter(r => r.status === 'fail').length,
+    failCategories: [...new Set(payload.results.filter(r => r.status === 'fail').map(r => r.category))],
+  });
+
+  const resp = await fetch(`${apiBase}/stash`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+    body: JSON.stringify({
+      data: JSON.stringify(payload),
+      fingerprint,
+    }),
+  });
+
+  if (!resp.ok) {
+    throw new Error(`stash upload failed: ${resp.status}`);
+  }
+
+  return resp.json() as Promise<StashResponse>;
+}
+
+/** 构建 claim URL */
+export function buildClaimUrl(token: string, apiBase: string): string {
+  const origin = apiBase.replace(/\/api\/v1\/?$/, '').replace(/\/$/, '');
+  return `${origin}/claim?t=${token}`;
+}
+
 /** 读取最近一次扫描报告（不含当前） */
 export function loadPreviousReport(): UploadPayload | null {
   const reportDir = getReportDir();


### PR DESCRIPTION
## Summary
- **P1**: agent events sync 后在 stderr 展示匹配结果和悬赏草稿状态，用户立即看到反馈
- **P2**: CLI 模式 scan 后自动上传 stash 到 AICOEVO（与 MacAICheck 对齐）

## 改动
- `bin/agent-lite.js`: syncEvents() 成功后打印匹配置信度、advice 摘要、悬赏草稿信息
- `src/privacy/uploader.ts`: 新增 `stashData()` 和 `buildClaimUrl()` 函数
- `src/main.ts`: CLI 模式 scan 后自动调用 stashData() 上传，失败不影响本地

## Test plan
- [x] TypeScript 编译通过
- [ ] 手动测试：CLI scan → 看到上传成功信息
- [ ] 手动测试：agent sync → 看到 stderr 反馈

🤖 Generated with [Claude Code](https://claude.com/claude-code)