### PR TITLE
feat: add error_type enum to all scanner results

### DIFF
--- a/src/scanners/admin-perms.ts
+++ b/src/scanners/admin-perms.ts
@@ -21,14 +21,15 @@ const scanner: Scanner = {
       };
     }
 
-    return {
-      id: this.id,
-      name: this.name,
-      category: this.category,
-      status: 'warn',
-      message: '当前非管理员权限，部分修复操作需要提升权限',
-      detail: '建议以管理员身份运行本工具以获得完整修复能力',
-    };
+      return {
+        id: this.id,
+        name: this.name,
+        category: this.category,
+        status: 'warn',
+        message: '当前非管理员权限，部分修复操作需要提升权限',
+        detail: '建议以管理员身份运行本工具以获得完整修复能力',
+        error_type: 'permission',
+      };
   },
 };
 

--- a/src/scanners/ccswitch.ts
+++ b/src/scanners/ccswitch.ts
@@ -107,6 +107,7 @@ const scanner: Scanner = {
       name: this.name,
       category: this.category,
       status: 'warn',
+      error_type: 'missing',
       message: 'CCSwitch 未安装（可选，多账号管理工具）',
       detail:
         'CCSwitch 是 Claude Code 多账号/API Key 切换工具。分为 CLI 版和 GUI 版。\n\n' +

--- a/src/scanners/claude-cli.ts
+++ b/src/scanners/claude-cli.ts
@@ -20,6 +20,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'warn',
+        error_type: 'missing',
         message: 'Claude Code CLI 未安装',
         detail: 'Claude Code 是 Anthropic 官方命令行 AI 编程助手。\n\n安装方法:\n  npm install -g @anthropic-ai/claude-code\n  国内镜像: npm install -g @anthropic-ai/claude-code --registry https://registry.npmmirror.com\n\n使用: claude\n首次运行需要登录 Anthropic 账号或配置 API Key',
       };

--- a/src/scanners/claude-config-health.ts
+++ b/src/scanners/claude-config-health.ts
@@ -31,6 +31,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'fail',
+        error_type: 'misconfigured',
         message: 'Claude Code 配置文件无法解析',
         detail: `文件: ${config.path}\n错误: ${config.error}`,
       };

--- a/src/scanners/cpp-compiler.ts
+++ b/src/scanners/cpp-compiler.ts
@@ -40,6 +40,7 @@ const scanner: Scanner = {
       name: this.name,
       category: this.category,
       status: 'fail',
+      error_type: 'missing',
       message: '未检测到 C/C++ 编译器（MSVC 或 GCC）',
       detail: '部分 Python 包需要编译器支持',
     };

--- a/src/scanners/cuda-version.ts
+++ b/src/scanners/cuda-version.ts
@@ -48,6 +48,7 @@ const scanner: Scanner = {
           status: 'warn',
           message: `驱动支持 CUDA ${cudaMatch[1]}，但 CUDA Toolkit 未安装`,
           detail: 'nvcc 不可用，建议安装 CUDA Toolkit',
+          error_type: 'outdated',
         };
       }
     }

--- a/src/scanners/dns-resolution.ts
+++ b/src/scanners/dns-resolution.ts
@@ -46,6 +46,7 @@ const scanner: Scanner = {
         status: failed.length === domains.length ? 'fail' : 'warn',
         message: `DNS 解析失败: ${failed.join(', ')}`,
         detail: failed.length < domains.length ? `正常: ${ok.join(', ')}` : '请检查 DNS 设置',
+        error_type: 'network',
       };
     }
 

--- a/src/scanners/env-path-length.ts
+++ b/src/scanners/env-path-length.ts
@@ -27,6 +27,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'fail',
+        error_type: 'misconfigured',
         message: `PATH 过长 (${length} 字符，接近系统上限 ${MAX_FAIL})`,
         detail: duplicates.length > 0
           ? `重复项:\n${duplicates.map(([p, c]) => `  ${p} (x${c})`).join('\n')}`
@@ -40,6 +41,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'warn',
+        error_type: 'misconfigured',
         message: `PATH 偏长或存在冗余 (${length} 字符，${entries.length} 个条目)`,
         detail: duplicates.length > 0
           ? `重复项:\n${duplicates.map(([p, c]) => `  ${p} (x${c})`).join('\n')}`

--- a/src/scanners/firewall-ports.ts
+++ b/src/scanners/firewall-ports.ts
@@ -59,6 +59,7 @@ const scanner: Scanner = {
       name: this.name,
       category: this.category,
       status: missing.length > 0 ? 'warn' : 'pass',
+      ...(missing.length > 0 && { error_type: 'permission' as const }),
       message: missing.length > 0
         ? `${missing.length} 个 AI 常用端口未发现显式入站放行规则`
         : 'AI 常用端口防火墙配置正常',

--- a/src/scanners/git-credential-health.ts
+++ b/src/scanners/git-credential-health.ts
@@ -25,6 +25,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'warn',
+        error_type: 'misconfigured',
         message: '未检测到 Git 凭据助手或 SSH Key',
         detail: '可使用 HTTPS credential helper，或在 ~/.ssh 中配置 id_ed25519 / id_rsa。',
       };

--- a/src/scanners/git-identity-config.ts
+++ b/src/scanners/git-identity-config.ts
@@ -20,6 +20,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'warn',
+        error_type: 'misconfigured',
         message: 'Git 全局身份未完整配置',
         detail: `user.name: ${userName || '(未设置)'}\nuser.email: ${userEmail || '(未设置)'}`,
       };

--- a/src/scanners/git-path.ts
+++ b/src/scanners/git-path.ts
@@ -21,6 +21,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'fail',
+        error_type: 'missing',
         message: '未检测到 Git',
       };
     }
@@ -74,6 +75,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'fail',
+        error_type: 'misconfigured',
         message: `Git PATH 不完整，缺少 ${missing.join('、')}，导致 ${missingCmds.join('、')} 不可用`,
         detail: `Git 安装目录: ${gitDir}\n缺少目录: ${missing.join('、')}\n不可用命令: ${missingCmds.join('、')}\n\n建议添加到系统 PATH:\n${missing.map(d => `${gitDir}\\${d === 'Git\\cmd' ? 'cmd' : d.replace('Git\\', '')}`).join('\n')}`,
       };
@@ -85,6 +87,7 @@ const scanner: Scanner = {
       name: this.name,
       category: this.category,
       status: 'warn',
+      error_type: 'misconfigured',
       message: `Git PATH 不够规范，缺少 ${missing.join('、')}（命令暂时可用但不稳定）`,
       detail: `建议将以下目录加入系统 PATH:\n${missing.map(d => `  ${gitDir}\\${d.replace('Git\\', '')}`).join('\n')}`,
     };

--- a/src/scanners/git.ts
+++ b/src/scanners/git.ts
@@ -17,6 +17,7 @@ const scanner: Scanner = {
         category: this.category,
         status: 'fail',
         message: 'Git 未安装或不在 PATH 中',
+        error_type: 'missing',
       };
     }
 
@@ -32,6 +33,7 @@ const scanner: Scanner = {
         category: this.category,
         status: 'warn',
         message: `Git 版本过旧 (${version})，建议升级到 2.30+`,
+        error_type: 'outdated',
       };
     }
 

--- a/src/scanners/gpu-driver.ts
+++ b/src/scanners/gpu-driver.ts
@@ -47,6 +47,7 @@ const scanner: Scanner = {
         status: 'warn',
         message: 'NVIDIA 驱动版本较旧，建议更新到 525+',
         detail,
+        error_type: 'outdated',
       };
     }
 

--- a/src/scanners/long-paths.ts
+++ b/src/scanners/long-paths.ts
@@ -30,6 +30,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'fail',
+        error_type: 'misconfigured',
         message: 'Windows 长路径支持未启用，可能导致 npm/git 长路径问题',
         detail: '注册表 LongPathsEnabled = 0',
       };

--- a/src/scanners/mcp-command-availability.ts
+++ b/src/scanners/mcp-command-availability.ts
@@ -49,6 +49,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: available.length > 0 ? 'warn' : 'fail',
+        error_type: 'missing',
         message: '部分 MCP server 启动命令不可用',
         detail: `可用:\n${available.join('\n') || '(无)'}\n\n不可用:\n${missing.join('\n')}`,
       };

--- a/src/scanners/mcp-config-health.ts
+++ b/src/scanners/mcp-config-health.ts
@@ -30,6 +30,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'fail',
+        error_type: 'misconfigured',
         message: 'MCP 配置文件无法解析',
         detail: `文件: ${config.path}\n错误: ${config.error}`,
       };

--- a/src/scanners/mirror-sources.ts
+++ b/src/scanners/mirror-sources.ts
@@ -50,6 +50,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'warn',
+        error_type: 'misconfigured',
         message: `${noMirror.length} 个包管理器未配置国内镜像`,
         detail: [...mirrors, ...noMirror].join('\n'),
       };

--- a/src/scanners/node-global-bin-path.ts
+++ b/src/scanners/node-global-bin-path.ts
@@ -15,6 +15,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'fail',
+        error_type: 'misconfigured',
         message: '无法获取 npm 全局安装路径',
       };
     }
@@ -30,6 +31,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'warn',
+        error_type: 'misconfigured',
         message: 'Node 全局 CLI 环境不完整',
         detail: `npm prefix: ${globalPrefix}\n在 PATH 中: ${inPath ? '是' : '否'}\nnpx 可用: ${hasNpx ? '是' : '否'}`,
       };

--- a/src/scanners/node-manager-conflict.ts
+++ b/src/scanners/node-manager-conflict.ts
@@ -37,6 +37,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'warn',
+        error_type: 'conflict',
         message: '检测到多个 Node 管理链路，可能导致命令漂移',
         detail: `node 路径:\n${locations.join('\n')}`,
       };

--- a/src/scanners/node-version.ts
+++ b/src/scanners/node-version.ts
@@ -17,6 +17,7 @@ const scanner: Scanner = {
         category: this.category,
         status: 'fail',
         message: 'Node.js 未安装',
+        error_type: 'missing',
       };
     }
 
@@ -30,6 +31,7 @@ const scanner: Scanner = {
         category: this.category,
         status: 'warn',
         message: `Node.js 版本过旧 (v${version})，建议 v18+`,
+        error_type: 'outdated',
       };
     }
 

--- a/src/scanners/openclaw-config-health.ts
+++ b/src/scanners/openclaw-config-health.ts
@@ -36,6 +36,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'fail',
+        error_type: 'misconfigured',
         message: 'OpenClaw 配置文件无法解析',
         detail: `文件: ${config.path}\n错误: ${config.error}`,
       };
@@ -50,6 +51,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'fail',
+        error_type: 'misconfigured',
         message: 'OpenClaw 配置包含明显占位密钥',
         detail: `文件: ${config.path}\n占位字段:\n${placeholders.map(item => item.key).join('\n')}`,
       };

--- a/src/scanners/openclaw.ts
+++ b/src/scanners/openclaw.ts
@@ -20,6 +20,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'warn',
+        error_type: 'missing',
         message: 'OpenClaw 未安装（可选）',
         detail: 'OpenClaw 是开源的 Claude Code 替代品，支持 OpenRouter/兼容 API。\n\n安装方法:\n  npm install -g openclaw\n  国内镜像: npm install -g openclaw --registry https://registry.npmmirror.com\n\n使用: openclaw\n需要配置 API Key（支持多种提供商）',
       };

--- a/src/scanners/package-managers.ts
+++ b/src/scanners/package-managers.ts
@@ -37,6 +37,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'fail',
+        error_type: 'missing',
         message: '未检测到任何包管理器',
       };
     }
@@ -50,6 +51,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'warn',
+        error_type: 'misconfigured',
         message: `核心包管理器不完整（${!hasPython ? '缺少 pip' : ''}${!hasPython && !hasNode ? '，' : ''}${!hasNode ? '缺少 npm' : ''}）`,
         detail: `已安装: ${found.join(', ')}${missing.length > 0 ? `\n未安装: ${missing.join(', ')}` : ''}`,
       };

--- a/src/scanners/path-chinese.ts
+++ b/src/scanners/path-chinese.ts
@@ -18,6 +18,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'fail',
+        error_type: 'misconfigured',
         message: '用户目录包含非 ASCII 字符（中文路径），可能导致部分 AI 工具异常',
         detail: `路径: ${home}`,
       };

--- a/src/scanners/powershell-policy.ts
+++ b/src/scanners/powershell-policy.ts
@@ -53,6 +53,7 @@ const scanner: Scanner = {
         status: 'fail',
         message: `PowerShell 执行策略为 "${policy}"，将阻止脚本运行`,
         detail: '建议执行: Set-ExecutionPolicy RemoteSigned -Scope CurrentUser',
+        error_type: 'misconfigured',
       };
     }
 

--- a/src/scanners/powershell-version.ts
+++ b/src/scanners/powershell-version.ts
@@ -46,6 +46,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'warn',
+        error_type: 'outdated',
         message: `仅安装了 Windows PowerShell ${ps5Ver}，建议升级到 PowerShell 7`,
         detail: `Windows PowerShell 5.x 是旧版本，缺少以下特性:\n- 并行执行 (ForEach-Object -Parallel)\n- 三元运算符 ($a ? $b : $c)\n- 管道链操作符 (&& 和 ||)\n- null 合并操作符 (??)\n- 更好的性能和跨平台兼容性\n\n安装命令: winget install Microsoft.PowerShell`,
       };
@@ -56,6 +57,7 @@ const scanner: Scanner = {
       name: this.name,
       category: this.category,
       status: 'fail',
+      error_type: 'outdated',
       message: '未检测到 PowerShell',
     };
   },

--- a/src/scanners/proxy-config.ts
+++ b/src/scanners/proxy-config.ts
@@ -43,6 +43,7 @@ const scanner: Scanner = {
       status: hasNoProxy ? 'pass' : 'warn',
       message: `检测到 ${found.length} 个代理环境变量${!hasNoProxy ? '（缺少 NO_PROXY）' : ''}`,
       detail: found.join('\n'),
+      ...(hasNoProxy ? {} : { error_type: 'misconfigured' }),
     };
   },
 };

--- a/src/scanners/python-env-alignment.ts
+++ b/src/scanners/python-env-alignment.ts
@@ -39,6 +39,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'fail',
+        error_type: 'missing',
         message: 'Python 不可用，无法校验项目环境',
       };
     }
@@ -49,6 +50,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'warn',
+        error_type: 'missing',
         message: 'pip 不可用，Python 依赖安装可能失败',
         detail: `python: ${python.stdout.trim()}`,
       };
@@ -65,6 +67,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'warn',
+        error_type: 'conflict',
         message: 'python 与 pip 可能来自不同环境',
         detail: `python: ${pythonPath}\npip: ${pipPath || pip.stdout.trim()}`,
       };

--- a/src/scanners/python-project-venv.ts
+++ b/src/scanners/python-project-venv.ts
@@ -30,6 +30,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'warn',
+        error_type: 'misconfigured',
         message: '检测到 Python 项目，但未发现项目级虚拟环境',
         detail: '建议在项目根目录创建 .venv 或 venv，避免污染系统 Python/Anaconda 环境。',
       };

--- a/src/scanners/python-versions.ts
+++ b/src/scanners/python-versions.ts
@@ -69,6 +69,7 @@ const scanner: Scanner = {
         category: this.category,
         status: 'fail',
         message: 'Python 未安装或未加入当前命令环境',
+        error_type: 'missing',
       };
     }
 
@@ -82,6 +83,7 @@ const scanner: Scanner = {
         status: 'warn',
         message: `检测到多个 Python 版本，可能存在冲突`,
         detail: versions.join('\n'),
+        error_type: 'conflict',
       };
     }
 
@@ -95,6 +97,7 @@ const scanner: Scanner = {
         category: this.category,
         status: 'warn',
         message: `Python 版本过旧 (${ver})，建议 3.8+`,
+        error_type: 'outdated',
       };
     }
 

--- a/src/scanners/shell-encoding-health.ts
+++ b/src/scanners/shell-encoding-health.ts
@@ -26,6 +26,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'warn',
+        error_type: 'misconfigured',
         message: `当前终端代码页为 ${codePage}，可能出现中文或 JSON 输出乱码`,
         detail: '建议使用 chcp 65001、PowerShell 7 或 Windows Terminal UTF-8 配置。',
       };

--- a/src/scanners/site-reachability.ts
+++ b/src/scanners/site-reachability.ts
@@ -36,6 +36,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'fail',
+        error_type: 'network',
         message: '所有 AI 站点不可达',
         detail: '请检查网络连接或代理设置',
       };
@@ -47,6 +48,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'warn',
+        error_type: 'network',
         message: `不可达: ${unreachable.join(', ')}`,
         detail: `可达: ${reachable.join(', ')}`,
       };

--- a/src/scanners/ssl-certs.ts
+++ b/src/scanners/ssl-certs.ts
@@ -37,6 +37,7 @@ const scanner: Scanner = {
         status: 'fail',
         message: '所有站点 SSL 连接失败',
         detail: '可能是网络代理或证书问题',
+        error_type: 'network',
       };
     }
 
@@ -47,6 +48,7 @@ const scanner: Scanner = {
         category: this.category,
         status: 'warn',
         message: `部分站点 SSL 连接失败: ${failed.join(', ')}`,
+        error_type: 'network',
       };
     }
 

--- a/src/scanners/temp-space.ts
+++ b/src/scanners/temp-space.ts
@@ -41,6 +41,7 @@ const scanner: Scanner = {
           status: 'fail',
           message: `${driveLetter}: 盘剩余空间不足 (${freeGB} GB < ${MIN_GB} GB)`,
           detail: `TEMP 目录: ${tempDir}`,
+          error_type: 'resource',
         };
       }
       return {

--- a/src/scanners/terminal-profile-health.ts
+++ b/src/scanners/terminal-profile-health.ts
@@ -37,6 +37,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'fail',
+        error_type: 'misconfigured',
         message: 'Windows Terminal 配置无法解析',
         detail: `文件: ${settings.path}\n错误: ${settings.error}`,
       };
@@ -55,6 +56,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'warn',
+        error_type: 'misconfigured',
         message: 'Windows Terminal 默认 profile 无法匹配到有效配置',
         detail: `文件: ${settings.path}`,
       };
@@ -66,6 +68,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'warn',
+        error_type: 'misconfigured',
         message: 'Windows Terminal 默认 profile 不是 PowerShell 7',
         detail: `默认 profile: ${name || defaultProfile}\ncommandline: ${commandline || '(未配置)'}`,
       };

--- a/src/scanners/time-sync.ts
+++ b/src/scanners/time-sync.ts
@@ -17,6 +17,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'warn',
+        error_type: 'misconfigured',
         message: '无法查询时间同步状态',
         detail: '可能时间服务未启动',
       };
@@ -33,6 +34,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'warn',
+        error_type: 'misconfigured',
         message: '时间同步源可能不可靠',
         detail: `源: ${sourceValue}\n上次同步: ${syncValue}`,
       };

--- a/src/scanners/types.ts
+++ b/src/scanners/types.ts
@@ -9,6 +9,18 @@ export type ScannerCategory =
 /** 检测状态 */
 export type ScanStatus = 'pass' | 'fail' | 'warn' | 'unknown';
 
+/** 错误类型分类（标准化二级分类，提升匹配精度） */
+export type ErrorType =
+  | 'missing'        // 工具未安装
+  | 'outdated'       // 版本过旧
+  | 'conflict'       // 版本/配置冲突
+  | 'misconfigured'  // 配置错误
+  | 'incompatible'   // 硬件/驱动不兼容
+  | 'permission'     // 权限不足
+  | 'network'        // 网络问题
+  | 'resource'       // 资源不足（显存/磁盘/内存）
+  | 'unknown';       // 无法判定
+
 /** 单个扫描结果 */
 export interface ScanResult {
   id: string;
@@ -21,6 +33,7 @@ export interface ScanResult {
   path?: string | null;
   fixCommand?: string | null;
   severity?: string | null;
+  error_type?: ErrorType;
 }
 
 /** Scanner 接口 */

--- a/src/scanners/unix-commands.ts
+++ b/src/scanners/unix-commands.ts
@@ -28,6 +28,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'fail',
+        error_type: 'missing',
         message: '所有常用 Unix 命令均不可用',
       };
     }
@@ -37,6 +38,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'warn',
+        error_type: 'missing',
         message: `缺少命令: ${missing.join(', ')}`,
         detail: `可用: ${available.join(', ')}`,
       };

--- a/src/scanners/uv-package-manager.ts
+++ b/src/scanners/uv-package-manager.ts
@@ -19,6 +19,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'warn',
+        error_type: 'missing',
         message: 'uv 未安装，Claude Code 的 Python MCP 服务器将无法运行',
         detail: 'uv 是高性能 Python 包管理器，Claude Code/OpenClaw 依赖它运行 Python MCP 服务器。\n\n安装方法:\n  PowerShell: irm https://astral.sh/uv/install.ps1 | iex\n  pip: pip install uv\n  winget: winget install astral-sh.uv\n  国内加速: pip install uv -i https://pypi.tuna.tsinghua.edu.cn/simple',
       };

--- a/src/scanners/virtualization.ts
+++ b/src/scanners/virtualization.ts
@@ -48,6 +48,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'warn',
+        error_type: 'incompatible',
         message: 'BIOS/UEFI 中的虚拟化未启用',
         detail: '请在 BIOS/UEFI 中启用 Intel VT-x / AMD-V；如需 WSL2 或 Docker，再启用对应 Windows 功能。',
       };

--- a/src/scanners/vram-usage.ts
+++ b/src/scanners/vram-usage.ts
@@ -55,6 +55,7 @@ const scanner: Scanner = {
         status: 'warn',
         message: '显存使用率 > 90%，可能影响 AI 训练/推理',
         detail: details.join('\n'),
+        error_type: 'resource',
       };
     }
 

--- a/src/scanners/wsl-version.ts
+++ b/src/scanners/wsl-version.ts
@@ -18,6 +18,7 @@ const scanner: Scanner = {
         name: this.name,
         category: this.category,
         status: 'warn',
+        error_type: 'missing',
         message: 'WSL 未安装或未初始化',
         detail: '建议安装 WSL2: wsl --install',
       };
@@ -42,6 +43,7 @@ const scanner: Scanner = {
       name: this.name,
       category: this.category,
       status: 'warn',
+      error_type: 'outdated',
       message: 'WSL 已安装但可能使用 WSL1，建议升级到 WSL2',
       detail: stdout.split('\n').slice(0, 5).join('\n'),
     };


### PR DESCRIPTION
## Summary
Add standardized ErrorType classification to all scanner fail/warn returns for improved matching accuracy on aicoevo.net.

## Changes
- Add ErrorType type definition in `src/scanners/types.ts`
- Add `error_type` field to all 43 scanner files with appropriate values:
  - `missing`: tools not installed, not in PATH
  - `outdated`: version too old
  - `conflict`: multiple versions, version manager conflicts
  - `misconfigured`: config errors, policy issues, proxy problems
  - `incompatible`: hardware/driver incompatibility
  - `permission`: admin/UAC issues
  - `network`: DNS, SSL, connectivity
  - `resource`: disk, VRAM, memory
  - `unknown`: unclassifiable

## Cross-repo PRs
- aicoevo-platform: gugug168/aicoevo-platform#89
- MacAICheck: gugug168/mac-aicheck#46

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)