### PR TITLE
fix: include error_type and path in stash upload

### DIFF
--- a/src/privacy/uploader.ts
+++ b/src/privacy/uploader.ts
@@ -83,6 +83,8 @@ export interface UploadPayload {
     detail?: string;
     version?: string | null;
     severity?: string | null;
+    error_type?: string;
+    path?: string | null;
     fixCommand?: string | null;
   }>;
   systemInfo: SystemInfo;
@@ -102,6 +104,8 @@ export function createPayload(results: ScanResult[], score: ScoreResult): Upload
       detail: r.detail ? sanitize(r.detail) : undefined,
       version: r.version || null,
       severity: r.severity || null,
+      error_type: r.error_type || undefined,
+      path: r.path || undefined,
       fixCommand: r.fixCommand ? sanitize(r.fixCommand) : null,
     })),
     systemInfo: collectSystemInfo(),


### PR DESCRIPTION
## Summary
- createPayload() 现在上传 `error_type` 和 `path` 字段到 stash API
- 修复扫描器已产出但未传输的数据丢失问题

## Test plan
- [x] TypeScript 编译通过
- [ ] 实际扫描测试验证 error_type 和 path 出现在上传数据中

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)