### PR TITLE
fix: switch uploads to scan intake

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -103,7 +103,9 @@ async function cliMode(wantJson: boolean, wantHtml: boolean) {
       const payload = createPayload(results, score);
       const apiBase = getCommunityApiBase();
       const resp = await stashData(payload, apiBase);
-      console.log(`\n[AICOEVO] 扫描数据已上传，查看方案: ${buildCommunityClaimUrl(resp.token)}`);
+      console.log(
+        `\n[AICOEVO] 扫描数据已上传，查看方案: ${resp.claim_url || buildCommunityClaimUrl(resp.token)}`,
+      );
     } catch (err) {
       // 上传失败不影响本地保存
     }
@@ -272,7 +274,7 @@ async function webMode(port: number) {
       if (url.pathname === '/api/stash' && req.method === 'POST') {
         try {
           const body = await req.json() as { data?: string; fingerprint?: string };
-          const remote = await requestRemoteJson(`${communityApiBase}/stash`, {
+          const remote = await requestRemoteJson(`${communityApiBase}/problem-briefs/scan-intake`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
             body,

--- a/src/privacy/uploader.ts
+++ b/src/privacy/uploader.ts
@@ -135,11 +135,13 @@ export function saveLocal(payload: UploadPayload): string {
 /** Stash API 响应 */
 export interface StashResponse {
   token: string;
-  claim_url: string;
-  ttl_seconds: number;
+  claim_url?: string;
+  ttl_seconds?: number;
+  problem_brief_id?: string;
+  evidence_pack_id?: string;
 }
 
-/** 上传扫描数据到 AICOEVO stash API（与 MacAICheck stashData 对齐） */
+/** 上传扫描数据到 AICOEVO scan-intake API（创建 stash + problem brief + evidence pack）。 */
 export async function stashData(payload: UploadPayload, apiBase: string): Promise<StashResponse> {
   const fingerprint = JSON.stringify({
     platform: 'Windows',
@@ -150,7 +152,7 @@ export async function stashData(payload: UploadPayload, apiBase: string): Promis
     failCategories: [...new Set(payload.results.filter(r => r.status === 'fail').map(r => r.category))],
   });
 
-  const resp = await fetch(`${apiBase}/stash`, {
+  const resp = await fetch(`${apiBase}/problem-briefs/scan-intake`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
     body: JSON.stringify({
@@ -160,7 +162,7 @@ export async function stashData(payload: UploadPayload, apiBase: string): Promis
   });
 
   if (!resp.ok) {
-    throw new Error(`stash upload failed: ${resp.status}`);
+    throw new Error(`scan intake upload failed: ${resp.status}`);
   }
 
   return resp.json() as Promise<StashResponse>;

--- a/tests/scan-intake.test.ts
+++ b/tests/scan-intake.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'bun:test';
+import { stashData, type UploadPayload } from '../src/privacy/uploader';
+
+describe('scan intake upload contract', () => {
+  test('uploads to problem-brief scan-intake endpoint', async () => {
+    const payload: UploadPayload = {
+      timestamp: new Date('2026-04-22T00:00:00.000Z').toISOString(),
+      score: 72,
+      results: [
+        {
+          id: 'cuda-version',
+          name: 'CUDA',
+          category: 'gpu',
+          status: 'warn',
+          message: 'Toolkit missing',
+          error_type: 'missing',
+        },
+      ],
+      systemInfo: {
+        os: 'Windows 11',
+        cpu: 'AMD Ryzen',
+        ramGB: 32,
+        gpu: 'RTX 4060',
+        diskFreeGB: 128,
+      },
+    };
+
+    const calls: Array<{ input: string; body?: string }> = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: string | URL, init?: RequestInit) => {
+      calls.push({ input: String(input), body: typeof init?.body === 'string' ? init.body : undefined });
+      return {
+        ok: true,
+        json: async () => ({
+          token: 'abc123',
+          claim_url: 'https://aicoevo.net/claim?t=abc123',
+          ttl_seconds: 900,
+          problem_brief_id: 'pb1',
+          evidence_pack_id: 'ep1',
+        }),
+      } as Response;
+    }) as typeof fetch;
+
+    try {
+      const result = await stashData(payload, 'https://aicoevo.net/api/v1');
+      expect(result.problem_brief_id).toBe('pb1');
+      expect(calls[0]?.input).toBe('https://aicoevo.net/api/v1/problem-briefs/scan-intake');
+      expect(calls[0]?.body).toContain('"data"');
+      expect(calls[0]?.body).toContain('"fingerprint"');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- switch WinAICheck uploads from legacy `/api/v1/stash` to `/api/v1/problem-briefs/scan-intake`
- accept the richer response contract (`claim_url`, `problem_brief_id`, `evidence_pack_id`) and prefer the server-provided claim URL in CLI output
- add a focused contract test for the new upload endpoint

## Validation
- `bun test tests/scan-intake.test.ts`
- `bunx tsc --noEmit`
- `bun run src/main.ts --help`