### PR TITLE
fix: restore sanitizer and proxy scanner test stability

### DIFF
--- a/src/privacy/sanitizer.ts
+++ b/src/privacy/sanitizer.ts
@@ -8,7 +8,7 @@ const patterns: { regex: RegExp; replacement: string; label: string }[] = [
   { regex: /(?:sk-|api[_-]?key[_-]?)([a-zA-Z0-9_-]{20,})/gi, replacement: '<API_KEY>', label: 'API Key' },
   { regex: /Bearer\s+[a-zA-Z0-9._-]+/gi, replacement: 'Bearer <TOKEN>', label: 'Bearer Token' },
   // Windows 用户名路径（支持带空格路径，不区分大小写）
-  { regex: /[a-zA-Z]:\\Users\\[^\\]+?(?=\\|[\r\n]|$)/gi, replacement: 'C:\\Users\\<USER>', label: '用户名路径' },
+  { regex: /[a-zA-Z]:\\Users\\[^\\\s]+(?=\\|[\r\n]|\s|$)/gi, replacement: 'C:\\Users\\<USER>', label: '用户名路径' },
   { regex: /\/Users\/[^\/]+?(?=\/|[\r\n]|$)/gi, replacement: '/Users/<USER>', label: 'Mac/Unix 用户名路径' },
   // 敏感 URL
   { regex: /https?:\/\/[^@\s]+:[^@\s]+@/g, replacement: 'http://<BASIC_AUTH>@', label: '基础认证' },

--- a/tests/integration/network-scanners.test.ts
+++ b/tests/integration/network-scanners.test.ts
@@ -13,6 +13,12 @@ describe('proxy-config scanner', () => {
   afterEach(teardownMock);
 
   test('无代理 → pass', async () => {
+    setupMock(new Map([
+      ['reg query "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings"', {
+        stdout: '',
+        exitCode: 1,
+      }],
+    ]));
     // 清除代理环境变量（Windows 不区分大小写）
     await withEnv({
       HTTP_PROXY: '',


### PR DESCRIPTION
## Summary
- stop Windows user-path sanitization from swallowing trailing secrets
- isolate proxy-config no-proxy test from runner registry proxy state

## Root cause
- username path regex consumed trailing text after the username segment
- proxy-config integration test only cleared env vars, but scanner now also reads Windows registry proxy settings

## Verification
- bun test tests\\calculator-sanitizer.test.ts
- bun test tests\\integration\\network-scanners.test.ts
- bun run test:all