### PR TITLE
fix: accept nested owner repair metadata

### DIFF
--- a/bin/agent-lite.js
+++ b/bin/agent-lite.js
@@ -1549,8 +1549,13 @@ function isOwnerRepairTask(item = {}) {
 }
 
 function ownerRepairScannerId(item = {}) {
+  const task = ownerRepairExecutionTask(item);
+  const repairCapability = task.repair_capability && typeof task.repair_capability === 'object'
+    ? task.repair_capability
+    : {};
   return String(
-    ownerRepairExecutionTask(item).scanner_id
+    task.scanner_id
+    || repairCapability.scanner_id
     || item.scanner_id
     || item.scannerId
     || ''
@@ -1558,17 +1563,45 @@ function ownerRepairScannerId(item = {}) {
 }
 
 function ownerRepairConsentGranted(item = {}) {
-  const consentState = String(item.consent_state || '').trim().toLowerCase();
-  const automationMode = String(item.automation_mode || '').trim();
+  const task = ownerRepairExecutionTask(item);
+  const prepareState = item.prepare_state && typeof item.prepare_state === 'object'
+    ? item.prepare_state
+    : {};
+  const consentState = String(
+    item.consent_state
+    || prepareState.consent_state
+    || task.consent_state
+    || ''
+  ).trim().toLowerCase();
+  const automationMode = String(
+    item.automation_mode
+    || prepareState.automation_mode
+    || task.automation_mode
+    || ''
+  ).trim();
   return consentState === 'granted' || automationMode === 'full_auto_limited';
 }
 
 function ownerRepairRollbackReady(item = {}) {
+  const task = ownerRepairExecutionTask(item);
+  const prepareState = item.prepare_state && typeof item.prepare_state === 'object'
+    ? item.prepare_state
+    : {};
+  const rollbackState = (
+    task.rollback_state && typeof task.rollback_state === 'object'
+      ? task.rollback_state
+      : item.rollback_state && typeof item.rollback_state === 'object'
+        ? item.rollback_state
+        : {}
+  );
+  if (prepareState.rollback_ready === true) return true;
+  if (rollbackState.available === true) return true;
   return String(item.rollback_state || '').trim() === 'ready';
 }
 
 function ownerRepairRiskAllowed(item = {}) {
-  return String(item.risk_level || '').trim() === 'L2';
+  const task = ownerRepairExecutionTask(item);
+  return String(item.risk_level || task.risk_level || '').trim() === 'L2';
 }
 
 function ownerRepairGate(item = {}, decision = {}) {

--- a/tests/agent-protocol-v2.test.ts
+++ b/tests/agent-protocol-v2.test.ts
@@ -1815,6 +1815,103 @@ describe('worker-on (TASK-090)', () => {
     expect(body.proof_payload.after_context.rollback).toBeDefined();
   });
 
+  test('worker daemon accepts nested owner repair metadata from platform status payloads', async () => {
+    const root = createTempRoot();
+    roots.push(root);
+    setupWorkerConfig(root, { profileId: 'prof-owner' });
+
+    const requests: Array<{ url: string; body?: string }> = [];
+    let fetchCount = 0;
+    const io = createIo();
+    const code = await agentMain(['worker', 'daemon', '--worker-interval', '10'], {
+      baseDir: root,
+      executeOwnerRepairImpl: async ({ scannerId, executionTask }) => ({
+        ok: true,
+        result: 'success',
+        scannerId: scannerId || executionTask?.repair_capability?.scanner_id,
+        summary: 'owner repair passed',
+        commandsRun: ['netsh advfirewall firewall add rule name="Gradio" dir=in action=allow protocol=TCP localport=7860'],
+        stdout: 'OK',
+        stderr: '',
+        beforeScan: { status: 'fail', message: 'missing inbound rules' },
+        afterScan: { status: 'pass', message: 'all inbound rules present' },
+        diffSummary: 'firewall rules missing -> present',
+        backup: { backup_id: 'backup-fw-1', timestamp: '2026-05-03T00:00:00Z' },
+        rollback: { attempted: false, result: 'not_needed' },
+      }),
+      fetchImpl: async (url, init) => {
+        requests.push({ url, body: init?.body ? String(init.body) : undefined });
+        fetchCount++;
+        if (fetchCount >= 3) {
+          const config = _testHelpers.loadConfig({ baseDir: root });
+          config.workerEnabled = false;
+          _testHelpers.saveConfig(config, { baseDir: root });
+        }
+        if (url.includes('/heartbeat')) return mockResponse({ recommended_bounties: [] });
+        if (url.includes('/status')) {
+          return mockResponse({
+            pending_owner_verifications: [{
+              bounty_id: 'b_owner_repair_nested',
+              answer_id: 'a_owner_repair_nested',
+              title: 'repair firewall ports',
+              solution_summary: 'Auto repair firewall ports',
+              submitted_at: '2026-05-03T00:00:00Z',
+              deadline_at: '2026-05-04T00:00:00Z',
+              execution_task: {
+                kind: 'owner_repair',
+                risk_level: 'L2',
+                repair_capability: {
+                  requested: true,
+                  scanner_id: 'firewall-ports',
+                  fixer_id: 'firewall-ports-fixer',
+                },
+                rollback_state: {
+                  available: true,
+                  status: 'available',
+                },
+              },
+              prepare_state: {
+                prepared: true,
+                prepared_action: 'run_repair_now',
+                consent_state: 'granted',
+                rollback_ready: true,
+              },
+              execution_decision: {
+                decision: 'auto_validate',
+                phase: 'owner_verification',
+                current_profile_is_target: true,
+                target_route: {
+                  profile_id: 'prof-owner',
+                  device_id: 'device-test',
+                  agent_type: 'custom',
+                },
+              },
+            }],
+          });
+        }
+        if (url.includes('/owner-validation-tasks/prepare')) {
+          return mockResponse({
+            prepared: true,
+            prepared_action: 'run_repair_now',
+            prepare_state: { prepared: true, prepared_action: 'run_repair_now', consent_state: 'granted' },
+          });
+        }
+        if (url.includes('/owner-verify')) {
+          return mockResponse({ review_status: 'pending_review', owner_score: 60, total_score: 60, threshold: 70 });
+        }
+        return mockResponse({});
+      },
+    }, io.io);
+
+    expect(code).toBe(0);
+    const ownerVerifyRequest = requests.find(entry => entry.url.includes('/owner-verify'));
+    expect(ownerVerifyRequest).toBeDefined();
+    const body = JSON.parse(ownerVerifyRequest?.body || '{}');
+    expect(body.artifacts.owner_repair_mode).toBe(true);
+    expect(body.artifacts.owner_repair_scanner_id).toBe('firewall-ports');
+    expect(body.proof_payload.after_context.owner_repair_scanner_id).toBe('firewall-ports');
+  });
+
   test('worker daemon skips reviewer verification when command is safe but not a real validation', async () => {
     const root = createTempRoot();
     roots.push(root);


### PR DESCRIPTION
## Summary
- accept nested xecution_task.repair_capability.scanner_id metadata for owner repair tasks
- read consent, rollback, and risk gates from nested owner-repair payload fields
- add a regression test covering the current platform status payload shape

## Why
TASK-230 Windows production evidence exposed a real gap: platform had already advanced the machine-origin owner repair task to un_repair_now, but WinAICheck still skipped auto-execution because it only read legacy flat owner-repair fields.

## Verification
- un test tests\\agent-protocol-v2.test.ts
- real Windows production run: owner repair for bounty 3fe59e11af / answer dcc94fdcbd submitted successfully after this fix