### PR TITLE
TASK-254: send readable Windows bind device info

### DIFF
--- a/bin/agent-lite.js
+++ b/bin/agent-lite.js
@@ -441,6 +441,15 @@ function openExternalUrl(url, deps = {}) {
   });
 }
 
+function detectWindowsDeviceInfo(deps = {}) {
+  const platform = String(deps.platform || process.platform || '').toLowerCase();
+  if (platform !== 'win32') return 'Windows';
+  const release = String(deps.osRelease || os.release() || '').trim();
+  if (release.startsWith('10.0.22')) return 'Windows 11';
+  if (release.startsWith('10.0')) return 'Windows 10';
+  return 'Windows';
+}
+
 function today(deps = {}) {
   return nowIso(deps).slice(0, 10);
 }
@@ -4514,7 +4523,7 @@ export async function main(argv = process.argv.slice(2), deps = {}, io = {}) {
 
     // 新流程：OAuth 设备流（自动打开浏览器）
     const agentName = String(args.agent || 'unknown').trim();
-    const deviceInfo = `${os.hostname()}/${process.platform}`;
+    const deviceInfo = detectWindowsDeviceInfo(deps);
 
     out.write(`正在发起设备绑定...\n`);
 
@@ -5142,6 +5151,7 @@ export const _testHelpers = {
   saveConfig,
   heartbeatAgentV2,
   runDraftOrganizerOnce,
+  detectWindowsDeviceInfo,
 };
 
 let isDirectExecution = false;

--- a/tests/agent-protocol-v2.test.ts
+++ b/tests/agent-protocol-v2.test.ts
@@ -2125,6 +2125,8 @@ describe('worker-on (TASK-090)', () => {
       homeDir: root,
       openBrowser: () => {},
       sleep: async () => {},
+      platform: 'win32',
+      osRelease: '10.0.22631',
       fetchImpl: async (url) => {
         requests.push(String(url));
         if (String(url).includes('/bind/request')) {
@@ -2150,6 +2152,7 @@ describe('worker-on (TASK-090)', () => {
     expect(io.output).toContain('网页中点一次确认即可完成绑定');
     expect(io.output).toContain('绑定成功');
     expect(requests.some(url => url.includes('/bind/request'))).toBe(true);
+    expect(requests[0]).toContain('device_info=Windows%2011');
     expect(requests.some(url => url.includes('/bind/poll'))).toBe(true);
     expect(_testHelpers.loadConfig({ baseDir: root }).profileId).toBe('prof_device_flow');
   });
@@ -2190,4 +2193,5 @@ describe('worker-on (TASK-090)', () => {
     expect(io.output).toContain('已自动打开浏览器');
     expect(_testHelpers.loadConfig({ baseDir: root }).profileId).toBe('prof_device_flow_open');
   });
+
 });


### PR DESCRIPTION
## Summary
- replace raw hostname/platform bind metadata with readable Windows labels
- map current Windows releases to Windows 10 / Windows 11 values
- add bind-flow coverage for the encoded device_info value

## Testing
- bun test tests/agent-protocol-v2.test.ts