### PR TITLE
[codex] detect Claude hook PowerShell env risks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - 新增 ground-truth 审计基础设施：8 个验证器、统一 `scripts/audit.ts` CLI、CI fixture，以及 `scanWithDiagnostic()` 决策链采集。
 - 新增集中式扫描器阈值配置（Git / GPU / Node / 镜像源）和 `compareVersions()`，统一扫描器门槛管理。
+- 新增 Claude Code Hook Windows 兼容性检测，识别 `powershell -Command "$env:..."` 这类会触发 `:AUTO_LOOP_URL` / `CommandNotFoundException` 的 hook 配置，并提示改用 `-File` 加显式参数。
 
 ### Changed
 - Agent 启用和自更新现在会自动迁移 Claude Code 到 settings hook，并清理旧 PowerShell `function claude` wrapper，避免交互启动被误判为 `--print` 模式。

--- a/README.md
+++ b/README.md
@@ -234,11 +234,11 @@ Phase 6 的 owner task 现已支持一个受限的 Windows 本地安全自动修
 |:-----|:-------|:-----|
 | 路径与环境 | 中文路径、空格路径、长路径、PATH长度、临时空间 | x1.5 |
 | 权限与安全 | 管理员权限、PowerShell策略、防火墙、时间同步 | x1.2 |
-| 核心工具链 | Git、Node.js、Python、C++编译器、包管理器、Unix命令 | x1.0 |
+| 核心工具链 | Git、Node.js、Python、C++编译器、包管理器、Unix命令、Claude Code Hook 兼容性 | x1.0 |
 | 网络与镜像 | 镜像源、代理、SSL证书、AI站点可达性、DNS | x1.0 |
 | 显卡与子系统 | GPU驱动、虚拟化、WSL、CUDA、显存 | x0.8 |
 
-共 **25 个检查项**，全部配备修复建议。
+共 **38 个检查项**，全部配备修复建议。
 
 ## 修复系统
 
@@ -266,8 +266,8 @@ bun run build
 src/
 ├── main.ts           # 入口
 ├── constants.ts      # 版本号与全局常量
-├── scanners/         # 25 个扫描器
-├── fixers/           # 25 个修复器（backup → execute → rollback）
+├── scanners/         # 38 个扫描器
+├── fixers/           # 修复器（backup → execute → rollback）
 ├── scoring/          # 加权评分
 ├── installers/      # AI 工具安装器（Claude Code、OpenClaw、CCSwitch、汉化）
 ├── web/              # Web UI（诊断 + 安装 + 资源导航）

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "winaicheck",
   "version": "0.3.16",
-  "description": "Windows AI 开发环境一键诊断与修复工具 - 扫描 37 个维度，反馈收集，社区悬赏，经验值系统",
+  "description": "Windows AI 开发环境一键诊断与修复工具 - 扫描 38 个维度，反馈收集，社区悬赏，经验值系统",
   "type": "module",
   "bin": {
     "winaicheck": "bin/winaicheck.js",

--- a/src/scanners/claude-hook-compatibility.ts
+++ b/src/scanners/claude-hook-compatibility.ts
@@ -1,0 +1,201 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
+import { basename, join } from 'path';
+import type { ScanResult, Scanner } from './types';
+import { registerScanner } from './registry';
+import { getHomeDir, getProjectDir, parseJsonLoose } from './config-utils';
+
+interface HookCommand {
+  file: string;
+  event: string;
+  matcher: string;
+  command: string;
+}
+
+interface HookConfig {
+  path: string;
+  data?: any;
+  error?: string;
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function getProjectHookJsonCandidates(projectClaudeDir: string): string[] {
+  if (!existsSync(projectClaudeDir)) return [];
+  try {
+    return readdirSync(projectClaudeDir)
+      .filter(name => /^hooks.*\.json$/i.test(name))
+      .map(name => join(projectClaudeDir, name))
+      .filter(path => {
+        try {
+          return statSync(path).isFile();
+        } catch {
+          return false;
+        }
+      });
+  } catch {
+    return [];
+  }
+}
+
+export function getClaudeHookConfigCandidates(): string[] {
+  const homeClaudeDir = join(getHomeDir(), '.claude');
+  const projectClaudeDir = join(getProjectDir(), '.claude');
+  return unique([
+    join(homeClaudeDir, 'settings.json'),
+    join(homeClaudeDir, 'settings.local.json'),
+    join(projectClaudeDir, 'settings.json'),
+    join(projectClaudeDir, 'settings.local.json'),
+    ...getProjectHookJsonCandidates(projectClaudeDir),
+  ]);
+}
+
+function readHookConfigs(paths: string[]): HookConfig[] {
+  return paths
+    .filter(path => existsSync(path))
+    .map(path => {
+      try {
+        return { path, data: parseJsonLoose(readFileSync(path, 'utf-8')) };
+      } catch (error) {
+        return {
+          path,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    });
+}
+
+function matcherToText(matcher: unknown): string {
+  if (typeof matcher === 'string') return matcher;
+  if (!matcher || typeof matcher !== 'object') return '';
+  const data = matcher as Record<string, unknown>;
+  const event = typeof data.event === 'string' ? data.event : '';
+  const tool = typeof data.tool === 'string'
+    ? data.tool
+    : Array.isArray(data.tools)
+      ? data.tools.filter(item => typeof item === 'string').join('|')
+      : '';
+  return [event, tool].filter(Boolean).join(':') || JSON.stringify(data);
+}
+
+function collectFromEntry(file: string, entry: any, eventHint = ''): HookCommand[] {
+  if (!entry || typeof entry !== 'object') return [];
+  const matcher = matcherToText(entry.matcher);
+  const event = eventHint || (matcher.startsWith('PostToolUse') ? 'PostToolUse' : '');
+  const hooks = Array.isArray(entry.hooks) ? entry.hooks : [];
+  return hooks
+    .filter((hook: any) => hook && typeof hook === 'object' && typeof hook.command === 'string')
+    .map((hook: any) => ({
+      file,
+      event,
+      matcher,
+      command: hook.command,
+    }));
+}
+
+export function collectClaudeHookCommands(configs: HookConfig[]): HookCommand[] {
+  const commands: HookCommand[] = [];
+  for (const config of configs) {
+    if (!config.data || typeof config.data !== 'object') continue;
+    const hooks = config.data.hooks;
+    if (Array.isArray(hooks)) {
+      for (const entry of hooks) commands.push(...collectFromEntry(config.path, entry));
+      continue;
+    }
+    if (hooks && typeof hooks === 'object') {
+      for (const [event, entries] of Object.entries(hooks)) {
+        if (!Array.isArray(entries)) continue;
+        for (const entry of entries) commands.push(...collectFromEntry(config.path, entry, event));
+      }
+    }
+  }
+  return commands;
+}
+
+function isPowerShellEnvCommandRisk(command: string): boolean {
+  return /(powershell(?:\.exe)?|pwsh(?:\.exe)?)/i.test(command)
+    && /(^|\s)-Command(\s|$)/i.test(command)
+    && /\$env:/i.test(command);
+}
+
+function summarizeCommand(command: string): string {
+  const shell = command.match(/\b(?:powershell(?:\.exe)?|pwsh(?:\.exe)?)\b/i)?.[0] || 'PowerShell';
+  const envRefCount = unique([...command.matchAll(/\$env:([A-Z0-9_]+)/gi)].map(match => match[1].toUpperCase())).length;
+  const script = command.match(/[&]\s+([^\s"']+\.ps1)\b/i)?.[1];
+  return [
+    shell,
+    '-Command',
+    envRefCount > 0 ? `检测到 ${envRefCount} 个 $env 引用` : '检测到 $env 引用',
+    script ? `script=${script}` : '',
+  ].filter(Boolean).join(' ');
+}
+
+function formatRisk(item: HookCommand): string {
+  const event = item.event || '(未声明事件)';
+  const matcher = item.matcher || '(未声明 matcher)';
+  return [
+    `文件: ${item.file}`,
+    `事件: ${event}`,
+    `匹配: ${matcher}`,
+    `命令摘要: ${summarizeCommand(item.command)}`,
+  ].join('\n');
+}
+
+const scanner: Scanner = {
+  id: 'claude-hook-compatibility',
+  name: 'Claude Code Hook Windows 兼容性检测',
+  category: 'toolchain',
+  affectsScore: false,
+
+  async scan(): Promise<ScanResult> {
+    const configs = readHookConfigs(getClaudeHookConfigCandidates());
+    const parseErrors = configs.filter(config => config.error);
+
+    if (parseErrors.length > 0) {
+      return {
+        id: this.id,
+        name: this.name,
+        category: this.category,
+        status: 'fail',
+        error_type: 'misconfigured',
+        message: 'Claude Code hook 配置文件无法解析',
+        detail: parseErrors.map(config => `文件: ${config.path}\n错误: ${config.error}`).join('\n\n'),
+      };
+    }
+
+    const commands = collectClaudeHookCommands(configs);
+    const risks = commands.filter(item => isPowerShellEnvCommandRisk(item.command));
+
+    if (risks.length > 0) {
+      return {
+        id: this.id,
+        name: this.name,
+        category: this.category,
+        status: 'warn',
+        error_type: 'misconfigured',
+        message: `发现 ${risks.length} 条 Claude Code hook 可能在 Windows 下误解析 $env 变量`,
+        detail: [
+          ...risks.map(formatRisk),
+          '建议: 将 PowerShell hook 改成 -File 脚本.ps1 -参数 值，例如:',
+          'powershell -NoProfile -ExecutionPolicy Bypass -File scripts/post-edit-verify.ps1 -OutputDir .tmp/auto-loop -WebsiteUrl http://aicoevo.net',
+          '原因: JSON 双引号命令中嵌套 -Command "$env:..." 时，外层 shell 可能先展开 $env，最终触发 :AUTO_LOOP_URL 这类 CommandNotFoundException。',
+        ].join('\n\n'),
+      };
+    }
+
+    const checked = configs.map(config => config.path);
+    return {
+      id: this.id,
+      name: this.name,
+      category: this.category,
+      status: 'pass',
+      message: '未发现 Claude Code hook Windows 兼容性风险',
+      detail: checked.length > 0
+        ? `已检查:\n${checked.map(path => `${basename(path)}: ${path}`).join('\n')}`
+        : '未发现 Claude Code hook 配置文件。',
+    };
+  },
+};
+
+registerScanner(scanner);

--- a/src/scanners/index.ts
+++ b/src/scanners/index.ts
@@ -42,6 +42,7 @@ import './claude-cli.js';
 import './openclaw.js';
 import './ccswitch.js';
 import './claude-config-health.js';
+import './claude-hook-compatibility.js';
 import './openclaw-config-health.js';
 import './mcp-config-health.js';
 import './mcp-command-availability.js';

--- a/tests/claude-hook-compatibility.test.ts
+++ b/tests/claude-hook-compatibility.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import '../src/scanners/claude-hook-compatibility';
+import { getScannerById } from '../src/scanners/registry';
+
+const scanner = () => getScannerById('claude-hook-compatibility')!;
+
+describe('claude-hook-compatibility scanner', () => {
+  let tempDir = '';
+  let originalCwd = '';
+  let originalUserProfile: string | undefined;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'winaicheck-claude-hooks-'));
+    originalCwd = process.cwd();
+    originalUserProfile = process.env.USERPROFILE;
+    originalHome = process.env.HOME;
+    process.env.USERPROFILE = join(tempDir, 'home');
+    process.env.HOME = join(tempDir, 'home');
+    mkdirSync(join(process.env.USERPROFILE, '.claude'), { recursive: true });
+    process.chdir(tempDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originalUserProfile;
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('识别 PowerShell -Command 内嵌 $env 赋值导致的 Windows hook 风险', async () => {
+    mkdirSync(join(tempDir, '.claude'), { recursive: true });
+    writeFileSync(join(tempDir, '.claude', 'settings.json'), JSON.stringify({
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: 'Write|Edit|MultiEdit',
+            hooks: [
+              {
+                type: 'command',
+                command: 'powershell -NoProfile -ExecutionPolicy Bypass -Command "$env:AUTO_LOOP_URL=\'http://aicoevo.net\'; $env:OPENAI_API_KEY=\'sk-proj-abcdefghijklmnopqrstuvwxyz1234567890\'; & scripts/post-edit-verify.ps1 -OutputDir .tmp/auto-loop"',
+              },
+            ],
+          },
+        ],
+      },
+    }));
+
+    const result = await scanner().scan();
+
+    expect(result.status).toBe('warn');
+    expect(result.error_type).toBe('misconfigured');
+    expect(result.message).toContain('Claude Code hook');
+    expect(result.detail).toContain('settings.json');
+    expect(result.detail).toContain('PostToolUse');
+    expect(result.detail).toContain('Write|Edit|MultiEdit');
+    expect(result.detail).toContain('-File');
+    expect(result.detail).toContain('-WebsiteUrl');
+    expect(result.detail).not.toContain('sk-proj-abcdefghijklmnopqrstuvwxyz1234567890');
+    expect(result.detail).not.toContain('OPENAI_API_KEY');
+  });
+
+  test('允许使用 -File 和显式参数的 Claude hook 命令', async () => {
+    mkdirSync(join(tempDir, '.claude'), { recursive: true });
+    writeFileSync(join(tempDir, '.claude', 'hooks.example.json'), JSON.stringify({
+      hooks: [
+        {
+          matcher: {
+            event: 'PostToolUse',
+            tool: 'Write|Edit|MultiEdit',
+          },
+          hooks: [
+            {
+              type: 'command',
+              command: 'powershell -NoProfile -ExecutionPolicy Bypass -File scripts/post-edit-verify.ps1 -OutputDir .tmp/auto-loop -WebsiteUrl http://aicoevo.net',
+            },
+          ],
+        },
+      ],
+    }));
+
+    const result = await scanner().scan();
+
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('未发现');
+    expect(result.detail).toContain('hooks.example.json');
+  });
+
+  test('同时扫描用户级 Claude settings.json', async () => {
+    writeFileSync(join(process.env.USERPROFILE!, '.claude', 'settings.json'), JSON.stringify({
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: 'Write',
+            hooks: [
+              {
+                type: 'command',
+                command: 'pwsh -NoProfile -Command "$env:AUTO_LOOP_URL=\'http://aicoevo.net\'; ./scripts/post-edit-verify.ps1"',
+              },
+            ],
+          },
+        ],
+      },
+    }));
+
+    const result = await scanner().scan();
+
+    expect(result.status).toBe('warn');
+    expect(result.detail).toContain(join(process.env.USERPROFILE!, '.claude', 'settings.json'));
+    expect(result.detail).toContain('pwsh');
+  });
+});


### PR DESCRIPTION
## Summary
- Add a default Claude Code hook compatibility scanner for Windows.
- Detect hook commands like `powershell -Command "$env:..."` / `pwsh -Command "$env:..."` in user and project Claude settings.
- Report a non-scoring warning with a safer `-File` + explicit parameter pattern, without automatically editing user hook files.
- Update README/package metadata and CHANGELOG from 37 to 38 checks.

## Root Cause
On Windows, Claude hook commands stored as JSON strings can be passed through an outer shell before PowerShell receives them. When the hook embeds `-Command "$env:..."`, the outer shell may expand `$env` early and leave invalid fragments such as `:AUTO_LOOP_URL`, producing `CommandNotFoundException` in PostToolUse hooks.

## User Impact
WinAICheck can now warn users before this Claude Code hook quoting problem breaks their workflow. The scanner is read-only and recommends moving environment-dependent logic into a `.ps1` file invoked with `-File`, for example `powershell -File scripts/post-edit-verify.ps1 -WebsiteUrl ...`.

## Safety
- The new scanner has `affectsScore: false`, so this advisory warning does not lower the user environment score.
- Risk details summarize matching commands instead of printing the full hook command, avoiding accidental exposure of API keys or sensitive env names in local reports.

## Test Plan
- [x] `bun run typecheck`
- [x] `bun test tests/claude-hook-compatibility.test.ts`
- [x] `bun test`
- [x] `bun run build`
